### PR TITLE
Update fileset.py to fix HDLSearchPath pointing to the parent directory

### DIFF
--- a/src/simplhdl/pyedaa/fileset.py
+++ b/src/simplhdl/pyedaa/fileset.py
@@ -85,5 +85,5 @@ class FileSet(pm.FileSet):
             if isinstance(item, VerilogIncludeFile):
                 dirs.append(VerilogIncludeSearchPath(item.Path.parent.absolute()))
             elif isinstance(item, HDLSearchPath):
-                dirs.append(HDLSearchPath(item.Path.parent.absolute()))
+                dirs.append(HDLSearchPath(item.Path))
         return dirs

--- a/src/simplhdl/pyedaa/fileset.py
+++ b/src/simplhdl/pyedaa/fileset.py
@@ -85,5 +85,5 @@ class FileSet(pm.FileSet):
             if isinstance(item, VerilogIncludeFile):
                 dirs.append(VerilogIncludeSearchPath(item.Path.parent.absolute()))
             elif isinstance(item, HDLSearchPath):
-                dirs.append(HDLSearchPath(item.Path))
+                dirs.append(HDLSearchPath(item.Path.absolute()))
         return dirs


### PR DESCRIPTION
Fixes a small issue where "-search <path>" keywords, did not create appropriate incdir commands in the simulation flows