### PR TITLE
Adding support for -suppress compile option for simulation flows

### DIFF
--- a/src/simplhdl/flows/modelsim/modelsimflow.py
+++ b/src/simplhdl/flows/modelsim/modelsimflow.py
@@ -164,6 +164,8 @@ class ModelSimFlow(SimulationFlow):
             args.add(f"-L {name}")
         for name, value in self.project.Defines.items():
             args.add(f"+define+{name}={escape(value)}")
+        if self.project.Suppressions.count is not None:
+            args.add(f"-suppress {','.join(self.project.Suppressions)}")
         return ' '.join(list(args) + [self.args.vlog_args])
 
     def vcom_args(self) -> str:

--- a/src/simplhdl/flows/questasim/questasimflow.py
+++ b/src/simplhdl/flows/questasim/questasimflow.py
@@ -153,6 +153,8 @@ class QuestaSimFlow(SimulationFlow):
         args.add('-suppress vlog-2720')
         for name, value in self.project.Defines.items():
             args.add(f"+define+{name}={escape(value)}")
+        if self.project.Suppressions.count is not None:
+            args.add(f"-suppress {','.join(self.project.Suppressions)}")
         return ' '.join(list(args) + [self.args.vlog_args])
 
     def vcom_args(self) -> str:

--- a/src/simplhdl/flows/rivierapro/rivieraproflow.py
+++ b/src/simplhdl/flows/rivierapro/rivieraproflow.py
@@ -151,6 +151,8 @@ class RivieraProFlow(SimulationFlow):
             args.add('-dbg')
         for name, value in self.project.Defines.items():
             args.add(f"+define+{name}={escape(value)}")
+        if self.project.Suppressions.count is not None:
+            args.add(f"-suppress {','.join(self.project.Suppressions)}")
         return ' '.join(list(args) + [self.args.vlog_args])
 
     def vcom_args(self) -> str:

--- a/src/simplhdl/flows/vcs/vcsflow.py
+++ b/src/simplhdl/flows/vcs/vcsflow.py
@@ -159,6 +159,8 @@ class VcsFlow(SimulationFlow):
             args.add('-ntb_opts uvm')
         if self.is_verdi():
             args.add('-kdb')
+        if self.project.Suppressions.count is not None:
+            args.add(f"-suppress {','.join(self.project.Suppressions)}")
         return ' '.join(list(args) + [self.args.vlogan_args]).strip()
 
     def vhdlan_args(self) -> str:

--- a/src/simplhdl/pyedaa/project.py
+++ b/src/simplhdl/pyedaa/project.py
@@ -22,6 +22,7 @@ class Project(pm.Project):
     _hooks: Dict[str, List[str]]
     _repos: Dict[str, Repo]
     _reposdir: Optional[Path]
+    _verilogSuppressions: List[str]
 
     def __init__(
         self,
@@ -40,6 +41,7 @@ class Project(pm.Project):
         self._repos = dict()
         self._reposdir = None
         self._part = None
+        self._verilogSuppressions = []
 
     @property
     def ReposDir(self) -> Optional[Path]:
@@ -97,6 +99,13 @@ class Project(pm.Project):
 
     def AddDefine(self, name: str, value: str) -> None:
         self._verilogDefines[name] = value
+
+    @property
+    def Suppressions(self) -> List[str]:
+        return self._verilogSuppressions
+    
+    def AddSuppression(self, suppression: str) -> None:
+        self._verilogSuppressions.append(suppression)
 
     @property
     def Part(self) -> str:


### PR DESCRIPTION
Filesets support the option -suppress to explicitly add an error suppression during compilation in the various flows vlog, vlogan, like the following example from altera_io.f:
```
-suppress 2583,2241,2685,2718,13314,2687 -sv -work altera_io $QUARTUS_ROOTDIR/eda/sim_lib/tennm_atoms.sv
-suppress 2583,2241,2685,2718,13314,2687 -sv -work altera_io $QUARTUS_ROOTDIR/eda/sim_lib/mentor/tennm_atoms_ncrypt.sv
-sv -work altera_io $QUARTUS_ROOTDIR/eda/sim_lib/tennm_hssi_atoms.sv
```

This PR aims to add similar functionality to simplhdl simulation flows. In the case of Simpl the -suppress option applies to the entire project import list.