### PR TITLE
honor file order attribute in design file listing

### DIFF
--- a/src/simplhdl/project/design.py
+++ b/src/simplhdl/project/design.py
@@ -71,6 +71,8 @@ class Design:
         If no arguments are provided, all files are returned.
         """
         all_files = list(nx.topological_sort(self._files))
+        all_files.sort(key=lambda f: f.order)
+
         if type is None and not filters:
             file_collection = all_files
         else:

--- a/src/simplhdl/project/files.py
+++ b/src/simplhdl/project/files.py
@@ -29,6 +29,7 @@ class ConstraintOrder(float, Enum):
 class File:
     _cache = WeakValueDictionary()
     _default_usedin: list[str] = [UsedIn.SIMULATION, UsedIn.IMPLEMENTATION]
+    _default_order: ConstraintOrder = ConstraintOrder.NORMAL
     _default_encrypt: bool = False
     _path_relative_to: Path | None = None
 
@@ -50,6 +51,7 @@ class File:
         self._graph: nx.DiGraph[File] | None = None
         self._parent: Fileset | None = None
         self._usedin: list[str] = attributes.get("usedin", self._default_usedin)
+        self._order: float = attributes.get("order", self._default_order)
         self._encrypt: bool = attributes.get("encrypt", self._default_encrypt)
         self._initialized = True
 
@@ -94,6 +96,14 @@ class File:
     @encrypt.setter
     def encrypt(self, encrypt: bool) -> None:
         self._encrypt = encrypt
+
+    @property
+    def order(self) -> float:
+        return self._order
+
+    @order.setter
+    def order(self, order: float) -> None:
+        self._order = order
 
     def __str__(self) -> str:
         return str(self._path)
@@ -294,12 +304,10 @@ class ImplementationFile(File):
 
 class ConstraintFile(ImplementationFile):
     _default_scope: str | None = None
-    _default_order: ConstraintOrder = ConstraintOrder.NORMAL
 
     def __init__(self, file: Path, **attributes) -> None:
         super().__init__(file, **attributes)
         self._scope: str | None = attributes.get("scope", self._default_scope)
-        self._order: float = attributes.get("order", self._default_order)
 
     @property
     def scope(self) -> str | None:
@@ -308,10 +316,6 @@ class ConstraintFile(ImplementationFile):
     @scope.setter
     def scope(self, scope: str | None) -> None:
         self._scope = scope
-
-    @property
-    def order(self) -> float:
-        return self._order
 
 
 class SimulationFile(File):

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -153,6 +153,29 @@ def test_files_filtering(design):
     assert design.files(type=VhdlFile) == [vhdlfile]
 
 
+def test_files_retrieval_with_different_order_values(design):
+    fs = Fileset("fs")
+    design.add_fileset(fs)
+
+    low_order_file = File(Path("low_order_file.v"), order=10.0)
+    high_order_file = File(Path("high_order_file.v"), order=90.0)
+    mid_order_file = File(Path("mid_order_file.v"), order=50.0)
+    fs.add_file(low_order_file)
+    fs.add_file(high_order_file)
+    fs.add_file(mid_order_file)
+
+    assert design.files(order=FileOrder.HIERARCHY) == [
+        low_order_file,
+        mid_order_file,
+        high_order_file,
+    ]
+    assert design.files(order=FileOrder.COMPILE) == [
+        high_order_file,
+        mid_order_file,
+        low_order_file,
+    ]
+
+
 def test_validate_acyclic(design):
     fs1 = Fileset("fs1")
     fs2 = Fileset("fs2")


### PR DESCRIPTION
`Design.files()` now sorts files by each file's `order` value before applying `COMPILE`/`HIERARCHY` output ordering, so custom ordering is no longer ignored.

Also moves `order` handling into the base `File` class so all file types share the same behavior, and removes duplicated `order` logic from `ConstraintFile`.

Adds a regression test to verify mixed `order` values are returned correctly for both `HIERARCHY` and `COMPILE` modes.

Resolves #12